### PR TITLE
Refine website layout and image responsiveness

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,234 +4,34 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Agent Simulation</title>
-  <style>
-    html {
-    /* increase all fonts by x%: */
-    font-size: 150%;
-    }
-    body {
-      font-family: Arial, sans-serif;
-      padding: 20px;
-      text-align: center;
-    }
-    /* Header image under the title */
-    .header-image {
-    margin: 20px auto;       /* space above & below */
-    text-align: center;      /* center it */
-    }
-
-    .header-image img {
-    max-width: 1250px;        /* cap its width */
-    width: 100%;             /* responsive */
-    height: auto;            /* maintain aspect ratio */
-    border-radius: 4px;      /* optional rounding */
-    border: 1px solid #ccc;  /* subtle frame */
-    }
-    /* Settings row: inline form controls */
-    #simulation-form {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: center;
-      gap: 20px;
-      margin: 20px 0;
-    }
-    #simulation-form label {
-      display: flex;
-      flex-direction: column;
-      margin: 0;
-    }
-    #simulation-form select,
-    #simulation-form input[type="submit"] {
-      margin: 0 0 20px;
-    }
-
-    /* Options row: checkboxes */
-    .options-row {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      gap: 30px;
-      margin-bottom: 20px;
-    }
-    .options-row label {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      font-weight: normal;
-    }
-
-    form, .carousel, .bias-container, .analysis-container {
-      margin: 0 auto;
-    }
-
-    #agent-heading {
-      margin-bottom: 5px;
-      font-size: 1.8em;
-      font-weight: bold;
-    }
-    #agent-description {
-      margin-bottom: 10px;
-      font-style: italic;
-      color: #555;
-    }
-
-    /* New flex wrapper for Unity, agent images, and cue */
-    .carousel-flex {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      gap: 20px;
-      margin-bottom: 20px;
-    }
-    .carousel-flex img {
-      width: 300px;
-      height: auto;
-      object-fit: contain;
-    }
-
-    .image-container {
-      display: flex;
-      justify-content: center;
-      gap: 20px;
-    }
-    .media-item {
-      width: 750px;
-      height: 450px;
-      object-fit: contain;
-    }
-    #carousel-image-right {
-      border: 1px solid #000;
-    }
-
-    #agent-controls {
-      margin: 10px auto;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      gap: 10px;
-    }
-    #agent-index-input {
-      width: 60px;
-      text-align: center;
-    }
-
-    .agent-name {
-      margin-top: 10px;
-      font-weight: bold;
-    }
-
-    .notice {
-      color: red;
-      font-weight: bold;
-    }
-    .description {
-      margin-top: 10px;
-      font-style: italic;
-      color: #555;
-      text-align: center;
-    }
-
-    #bias-display,
-    #advanced-analysis {
-      margin-top: 40px;
-      text-align: center;
-      display: none;
-    }
-    .bias-container {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      gap: 20px;
-      margin-top: 10px;
-    }
-    .analysis-container {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 20px;
-      margin-top: 10px;
-    }
-    .bias-container img,
-    .bias-container video,
-    .analysis-container img {
-      max-width: 100%;
-      height: auto;
-    }
-
-    /* VR setup hidden by default */
-    #vr-setup {
-      display: none;
-      margin-bottom: 20px;
-    }
-    #vr-setup video {
-      max-width: 80%;
-      height: auto;
-    }
-    /* ─── 30% larger advanced‐analysis images ─── */
-    #advanced-analysis .media-item {
-    /* original was 750×450 */
-    width: calc(750px * 2);   /* = 975px */
-    height: calc(450px * 2);  /* = 585px */
-    }
-
-    /* ─── In the bias‐display row:
-       shrink the bias picture by 40%,
-       enlarge the other media (video) by 20% ─── */
-    #bias-display #bias-picture {
-    /* original was 750×450 */
-    width: calc(750px * 1.4);   /* = 450px */
-    height: calc(450px * 1.4);  /* = 270px */
-    }
-
-    #bias-display video {
-    /* original was 750×450 */
-    width: calc(750px * 1.5);   /* = 900px */
-    height: calc(450px * 1.5);  /* = 540px */
-    }
-    /* ─── Enlarge the two agent images in the carousel by 20% ─── */
-    #carousel .media-item {
-    /* original was 750×450 */
-    width: calc(750px * 1.0);   /* = 900px */
-    height: calc(450px * 1.0);  /* = 540px */
-    }
-
-    /* ─── Enlarge the Unity top‐view and environmental cue by 20% ─── */
-    /* .carousel-flex img#unity-image,  */
-    /* .carousel-flex img#env-cue-image {  */
-    /* original was 300px wide */
-    .carousel-flex img#unity-image {
-    width: calc(300px * 2.5);  /* = 360px */
-    height: auto;              /* keep aspect ratio */
-    border: 1px solid #000;
-    }
-    
-    }
-  </style>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>Behavioral Contagion in Human Groups</h1>
-  <!-- Header portrait below the main title -->
-  <div class="header-image">
-    <img id="head-pic" src="https://raw.githubusercontent.com/FabioReeh/Human-behavioural-contagion-simulation/main/docs/full_scene/head_pic.png" alt="Head Portrait" />
-  </div>
-  <div class="description">
+  <header>
+    <h1>Behavioral Contagion in Human Groups</h1>
+    <!-- Header portrait below the main title -->
+    <div class="header-image">
+      <img id="head-pic" src="https://raw.githubusercontent.com/FabioReeh/Human-behavioural-contagion-simulation/main/docs/full_scene/head_pic.png" alt="Head Portrait" />
+    </div>
+  </header>
+
+  <main>
+  <section id="intro" class="description">
     <p>We introduce a simulation of a collective decision-making process within a group of human agents performing a two-alternative choice task in a virtual reality (VR) environment.</p>
 
-    
     <p>In this simulation, agents make decisions based on two sources of information:</p>
     <ol>
       <li>Individual information they receive from their environment</li>
       <li>Social information they receive from observing the decisions of other agents</li>
     </ol>
 
-    
     <p>The simulations are based on a modified Drift Diffusion Model, adapted to incorporate both individual and social components of decision-making.</p>
 
     <p>The parameters listed below represent the key independent variables and assumptions that influence (or fail to influence) the dynamics of behavioral contagion within the group.</p>
-    
-  </div>
 
+  </section>
+
+  <section id="controls">
   <form id="simulation-form">
     <label for="agents">Number of Agents:
       <select id="agents" name="agents" required>
@@ -277,17 +77,19 @@
     <label><input type="checkbox" id="toggle-advanced" checked /> Show Advanced Analysis</label>
   </div>
 
+  </section>
+
   <div id="notice" class="notice"></div>
 
-  <div id="vr-setup">
+  <section id="vr-setup">
     <h2>VR setup</h2>
     <video id="vr-video" autoplay loop muted>
       <source id="vr-source" src="" type="video/mp4" />
       Your browser does not support the video tag.
     </video>
-  </div>
+  </section>
 
-  <div class="carousel" id="carousel" style="display: none;">
+  <section class="carousel" id="carousel" style="display: none;">
     <div id="agent-heading">Agent Images</div>
     <div id="agent-description" class="description">
       From left to the right: Top view of unity scene / Visualization of whos FOV is shown / FOV of selected agent / enviromental cue.
@@ -308,9 +110,9 @@
       <button id="next-agent">Next &raquo;</button>
     </div>
     <div id="agent-name" class="agent-name"></div>
-  </div>
+  </section>
 
-  <div id="bias-display">
+  <section id="bias-display">
     <h2>Bias Display</h2>
     <div class="description">Contagion dynamics and decision trajectories.</div>
     <div class="bias-container">
@@ -320,16 +122,18 @@
         Your browser does not support the video tag.
       </video>
     </div>
-  </div>
+  </section>
 
-  <div id="advanced-analysis">
+  <section id="advanced-analysis">
     <h2>Advanced Analysis</h2>
     <div class="description">Additional analysis plots based on your selections.</div>
     <div class="analysis-container">
       <img id="state-traj-img" src="" alt="State Trajectory" class="media-item" />
       <img id="wdegree-img" src="" alt="Weighted Degree Distribution" class="media-item" />
     </div>
-  </div>
+  </section>
+
+  </main>
 
   <script>
     let allowedCombinations = {};

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,151 @@
+html {
+  font-size: 150%;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+  text-align: center;
+}
+
+header {
+  margin-bottom: 20px;
+}
+
+.header-image img {
+  width: 100%;
+  max-width: 800px;
+  height: auto;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+section {
+  margin-bottom: 40px;
+}
+
+/* Simulation form */
+#simulation-form {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  margin: 20px 0;
+}
+#simulation-form label {
+  display: flex;
+  flex-direction: column;
+}
+#simulation-form select,
+#simulation-form input[type="submit"] {
+  margin-top: 5px;
+}
+
+/* Options row */
+.options-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+}
+.options-row label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: normal;
+}
+
+.notice {
+  color: red;
+  font-weight: bold;
+}
+
+.description {
+  font-style: italic;
+  color: #555;
+}
+
+#agent-heading {
+  margin-bottom: 5px;
+  font-size: 1.8em;
+  font-weight: bold;
+}
+
+#agent-description {
+  margin-bottom: 10px;
+}
+
+/* Carousel and media layout */
+.carousel-flex {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+}
+.carousel-flex > * {
+  flex: 1 1 250px;
+}
+
+.image-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+}
+
+.media-item {
+  width: 100%;
+  height: auto;
+}
+
+.image-container .media-item {
+  flex: 1 1 300px;
+}
+
+#agent-controls {
+  margin: 10px auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+}
+#agent-index-input {
+  width: 60px;
+  text-align: center;
+}
+
+.agent-name {
+  margin-top: 10px;
+  font-weight: bold;
+}
+
+.bias-container,
+.analysis-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+}
+
+.bias-container .media-item,
+.analysis-container .media-item {
+  flex: 1 1 300px;
+}
+
+#vr-setup,
+#bias-display,
+#advanced-analysis {
+  display: none;
+}
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+#vr-setup video {
+  max-width: 100%;
+}


### PR DESCRIPTION
## Summary
- Move massive inline styles into a new `docs/style.css` and restructure index with semantic header and section tags for clarity.
- Implement responsive flexbox layout and scaling rules so images and videos fit within standard viewports without zooming.
- Default optional sections (VR setup, bias display, advanced analysis) hidden for cleaner initial view.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bca7a3e788321b6be917acd63b284