### PR TITLE
Fix carousel navigation after image preload optimization

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -285,18 +285,18 @@
         displayPair(0);
         setupAgentControls();
       }
-
-      function preloadPair(idx) {
-        if (idx >= imagePairs.length) return;
-        const pair = imagePairs[idx];
-        if (pair.preloaded) return;
-        const img1 = new Image();
-        const img2 = new Image();
-        img1.src = pair.mainPath;
-        img2.src = pair.topPath;
-        pair.preloaded = true;
-      }
     });
+
+    function preloadPair(idx) {
+      if (idx >= imagePairs.length) return;
+      const pair = imagePairs[idx];
+      if (pair.preloaded) return;
+      const img1 = new Image();
+      const img2 = new Image();
+      img1.src = pair.mainPath;
+      img2.src = pair.topPath;
+      pair.preloaded = true;
+    }
 
     function displayPair(idx) {
       const left  = document.getElementById('top-view-image');


### PR DESCRIPTION
## Summary
- Move image preloading logic outside of form submit handler so `displayPair` can access it
- Ensure carousel controls are initialized allowing navigation through agent images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa213ecd08832193cc21fef378a9e1